### PR TITLE
Add protocols.io email for update message

### DIFF
--- a/templates/email/user_profile_updated_email.html
+++ b/templates/email/user_profile_updated_email.html
@@ -58,6 +58,10 @@ Github username: {{ data['github_username'] }} <br />
 Email for HuBMAP Slack Workspace: {{ data['slack_username'] }} <br />
 {% endif %}
 
+{% if 'protocols.io' in data['access_requests'] %}
+Email for protocols.io: {{ data['protocols_io_email'] }} <br />
+{% endif %}
+
 <br />
 
 <br />

--- a/templates/email/user_profile_updated_email.txt
+++ b/templates/email/user_profile_updated_email.txt
@@ -52,6 +52,9 @@ Github username: {{ data['github_username'] }}
 Email for HuBMAP Slack Workspace: {{ data['slack_username'] }}
 {% endif %}
 
+{% if 'protocols.io' in data['access_requests'] %}
+Email for protocols.io: {{ data['protocols_io_email'] }} <br />
+{% endif %}
 
 
 HuBMAP Member Registration and Profile


### PR DESCRIPTION
Address the request from Deb:
>When someone updates their profile and requests access to `protocols.io`, the email they want to use for `protocols.io` is not listed in the email sent to the ticket system.

>I have been able to find that information from the Connections plugin, but could you please add that field to the email?